### PR TITLE
Update for tiddlyweb 1.3.0

### DIFF
--- a/differ/setup.py
+++ b/differ/setup.py
@@ -2,7 +2,7 @@ AUTHOR = "FND"
 AUTHOR_EMAIL = "FNDo@gmx.net"
 NAME = "tiddlywebplugins.differ"
 DESCRIPTION = "TiddlyWeb plugin to compare tiddler revisions"
-VERSION = "0.6.3"
+VERSION = "0.6.4"
 
 
 import os
@@ -21,6 +21,6 @@ setup(
 	packages = find_packages(exclude="test"),
 	author_email = AUTHOR_EMAIL,
 	platforms = "Posix; MacOS X; Windows",
-	install_requires = ["setuptools", "tiddlyweb"],
+	install_requires = ["setuptools", "httpexceptor", "tiddlyweb>=1.3.0"],
 	zip_safe = False
 )

--- a/differ/test/test_differ.py
+++ b/differ/test/test_differ.py
@@ -13,7 +13,7 @@ def test_diff():
 	assert actual == expected
 
 	actual = diff(a, b, "unified")
-	expected = "---  \n\n+++  \n\n@@ -1,1 +1,1 @@\n\n-lorem ipsum\n+lorem foo ipsum"
+	expected = "--- \n\n+++ \n\n@@ -1 +1 @@\n\n-lorem ipsum\n+lorem foo ipsum"
 	assert actual == expected
 
 	actual = diff(a, b, "horizontal")

--- a/differ/tiddlywebplugins/differ.py
+++ b/differ/tiddlywebplugins/differ.py
@@ -27,15 +27,16 @@ TODO:
 import cgi
 import difflib
 
+from httpexceptor import HTTP400, HTTP404
+
 from tiddlyweb import control
 from tiddlyweb.model.tiddler import Tiddler
 from tiddlyweb.store import NoTiddlerError
 from tiddlyweb.serializer import Serializer
 from tiddlyweb.web import util as web
-from tiddlyweb.web.http import HTTP400, HTTP404
 
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 
 def init(config):


### PR DESCRIPTION
Set up to use httpexceptor

I note that the tests aren't passing for me, this appears to be a
slight different in how the diff output is presented, probably the
result of a version difference in difflib.

Sorry this is on my master, figured as it's a one off...

merge and release please and thank you?
